### PR TITLE
Attachment encoding to base64

### DIFF
--- a/code/mail/SESMailer.php
+++ b/code/mail/SESMailer.php
@@ -162,6 +162,7 @@ class SESMailer extends \Mailer {
 		$attachment->type = $file['mimetype'];
 		$attachment->filename = $as ?: basename($file['filename']);
 		$attachment->disposition = Mime\Mime::DISPOSITION_ATTACHMENT;
+		$attachment->encoding = Mime\Mime::ENCODING_BASE64;
 
 		$message->addPart($attachment);
 	}


### PR DESCRIPTION
![screen shot 2016-09-22 at 6 54 51 pm](https://cloud.githubusercontent.com/assets/8285818/18772092/0ad8e7c8-8112-11e6-8297-861973d0f629.png)
All attachments using $email = new Email(); are corrupted when receiving messages. This addition correct the problem.
