### PR TITLE
Add option to supply configuration using _ss_environment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Injector:
         signature_version: 'v4'
 ```
 
+An alternative way of providing credentials is to add those to the _ss_environment.php file, as shown below;
+If you use this method, then you don't need to supply the credentials in the YML configuation.
+
+```
+define('SS_AWS_KEY', '<key>');
+define('SS_AWS_SECRET', '<secret>');
+```
 
 If your SES account is configured with a single 'from' address having being 
 verified, you can set an 'always from' email address which will always be the 

--- a/code/mail/SESMailer.php
+++ b/code/mail/SESMailer.php
@@ -28,6 +28,18 @@ class SESMailer extends \Mailer {
     public $alwaysFrom;
 	
 	public function __construct($config) {
+        if (!empty($config) && !isset($config['credentials'])) {
+            // try to load the credentials from the Silverstripe configuration file
+            if (!defined('SS_AWS_KEY') || !defined('SS_AWS_SECRET')) {
+                throw new Exception("Undefined SS_AWS_KEY or SS_AWS_SECRET, unable to construct the AWS mailer");
+            }
+
+            $config['credentials'] = array(
+                'key' => defined('SS_AWS_KEY') ? SS_AWS_KEY : '',
+                'secret' => defined('SS_AWS_SECRET') ? SS_AWS_SECRET : '',
+            );
+        }
+
 		$this->client = SesClient::factory($config);
 		parent::__construct();
 	}


### PR DESCRIPTION
This change allows you to supply the AWS credentials using the _ss_environment.yml configuration file. If you don't add the security: section to the configuration, then the SESMailer will try to read the keys from defined constants instead.